### PR TITLE
Fixes a few typos, grammar errors and untranslated text in the Prompt Engineering Notebook.

### DIFF
--- a/1-Introduction to LLMs with OpenAI/Prompt_Engineering_OpenAI.ipynb
+++ b/1-Introduction to LLMs with OpenAI/Prompt_Engineering_OpenAI.ipynb
@@ -1,503 +1,504 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/peremartra/Large-Language-Model-Notebooks-Course/blob/main/1-Introduction%20to%20LLMs%20with%20OpenAI/Prompt_Engineering_OpenAI.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9c4700eb-00ef-433f-b574-2fb7f644226d",
-      "metadata": {
-        "id": "9c4700eb-00ef-433f-b574-2fb7f644226d"
-      },
-      "source": [
-        "<div align=\"center\">\n",
-        "<h1><a href=\"https://github.com/peremartra/Large-Language-Model-Notebooks-Course\">Learn by Doing LLM Projects</a></h1>\n",
-        "    <h3>Understand And Apply Large Language Models</h3>\n",
-        "    <h2>Brief Introducction to Prompt Engineering with OpenAI</h2>\n",
-        "    by <b>Pere Martra</b>\n",
-        "</div>\n",
-        "\n",
-        "<br>\n",
-        "\n",
-        "<div align=\"center\">\n",
-        "    &nbsp;\n",
-        "    <a target=\"_blank\" href=\"https://www.linkedin.com/in/pere-martra/\"><img src=\"https://img.shields.io/badge/style--5eba00.svg?label=LinkedIn&logo=linkedin&style=social\"></a>\n",
-        "    \n",
-        "</div>\n",
-        "\n",
-        "<br>\n",
-        "<hr>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "34723a72-1601-4685-a0ba-bff544425d48",
-      "metadata": {
-        "id": "34723a72-1601-4685-a0ba-bff544425d48"
-      },
-      "source": [
-        "In this notebook, we'll explore small prompt engineering techniques and recommendations that will help us elicit responses from the models that are better suited to our needs."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "id": "fe5f658a-708f-406c-a1cb-95e3482ae760",
-      "metadata": {
-        "id": "fe5f658a-708f-406c-a1cb-95e3482ae760",
-        "outputId": "a44c5457-94f4-4357-c66b-8682253aee0a",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m217.8/217.8 kB\u001b[0m \u001b[31m3.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m75.0/75.0 kB\u001b[0m \u001b[31m5.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m76.9/76.9 kB\u001b[0m \u001b[31m8.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m58.3/58.3 kB\u001b[0m \u001b[31m4.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-            "llmx 0.0.15a0 requires cohere, which is not installed.\n",
-            "llmx 0.0.15a0 requires tiktoken, which is not installed.\u001b[0m\u001b[31m\n",
-            "\u001b[0m"
-          ]
-        }
-      ],
-      "source": [
-        "!pip install -q openai==1.1.1"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "id": "fba193cc-d8a0-4ad2-8177-380204426859",
-      "metadata": {
-        "id": "fba193cc-d8a0-4ad2-8177-380204426859"
-      },
-      "outputs": [],
-      "source": [
-        "#if you need a API Key from OpenAI\n",
-        "#https://platform.openai.com/account/api-keys\n",
-        "\n",
-        "import openai\n",
-        "\n",
-        "openai.api_key=\"your-api-key\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "502cfc93-21e0-498f-9650-37bc6ddd514d",
-      "metadata": {
-        "id": "502cfc93-21e0-498f-9650-37bc6ddd514d"
-      },
-      "source": [
-        "# Formating the answer with Few Shot Samples.\n",
-        "\n",
-        "To obtain the model's response in a specific format, we have various options, but one of the most convenient is to use Few-Shot Samples. This involves presenting the model with pairs of user queries and example responses.\n",
-        "\n",
-        "Large models like GPT-3.5 respond well to the examples provided, adapting their response to the specified format.\n",
-        "\n",
-        "Depending on the number of examples given, this technique can be referred to as:\n",
-        "* Zero-Shot.\n",
-        "* One-Shot.\n",
-        "* Few-Shots.\n",
-        "\n",
-        "With One Shot should be enough, and it is recommended to use a maximum of six shots. It's important to remember that this information is passed in each query and occupies space in the input prompt.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "id": "a8344712-06d7-4c24-83d8-f36d62926e5e",
-      "metadata": {
-        "id": "a8344712-06d7-4c24-83d8-f36d62926e5e"
-      },
-      "outputs": [],
-      "source": [
-        "#Functio to call the model.\n",
-        "def return_OAIResponse(user_message, context):\n",
-        "\n",
-        "    newcontext = context.copy()\n",
-        "    newcontext.append({'role':'user', 'content':\"question: \" + user_message})\n",
-        "\n",
-        "    response = openai.chat.completions.create(\n",
-        "            model=\"gpt-3.5-turbo\",\n",
-        "            messages=newcontext,\n",
-        "            temperature=1,\n",
-        "        )\n",
-        "\n",
-        "    return (response.choices[0].message.content)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f611d73d-9330-466d-b705-543667e1b561",
-      "metadata": {
-        "id": "f611d73d-9330-466d-b705-543667e1b561"
-      },
-      "source": [
-        "In this zero-shots prompt we obtain a correct response, but without formatting, as the model incorporates the information he wants."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "id": "647790be-fdb8-4692-a82e-7e3a0220f72a",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "647790be-fdb8-4692-a82e-7e3a0220f72a",
-        "outputId": "4c4a9f4f-67c9-4a11-837f-1a1fd6b516ff"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Sebastian Vettel won the Formula 1 World Championship in 2010. He drove for the Red Bull Racing team and became the youngest ever F1 World Champion at the age of 23. Vettel secured a total of five race wins and nine pole positions during the 2010 season.\n"
-          ]
-        }
-      ],
-      "source": [
-        "#zero-shot\n",
-        "context_user = [\n",
-        "    {'role':'system', 'content':'You are an expert in F1.'}\n",
-        "]\n",
-        "print(return_OAIResponse(\"Who won the F1 2010?\", context_user))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e87a9a0a-c1b9-4759-b52f-f6547d29b4c8",
-      "metadata": {
-        "id": "e87a9a0a-c1b9-4759-b52f-f6547d29b4c8"
-      },
-      "source": [
-        "A un modelo tan grande y bueno como GPT 3.5 le basta un solo shot para aprende el formato de salida que esperamos.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "id": "33ac7693-6cf3-44f7-b2ff-55d8a36fe775",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "33ac7693-6cf3-44f7-b2ff-55d8a36fe775",
-        "outputId": "5278df23-8797-4dc2-9340-ac29c1318a9c"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Driver: Sebastian Vettel.\n",
-            "Team: Red Bull Racing.\n"
-          ]
-        }
-      ],
-      "source": [
-        "#one-shot\n",
-        "context_user = [\n",
-        "    {'role':'system', 'content':\n",
-        "     \"\"\"You are an expert in F1.\n",
-        "\n",
-        "     Who won the 2000 f1 championship?\n",
-        "     Driver: Michael Schumacher.\n",
-        "     Team: Ferrari.\"\"\"}\n",
-        "]\n",
-        "print(return_OAIResponse(\"Who won the F1 2011?\", context_user))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "32c454a8-181b-482b-873a-81d6ffde4674",
-      "metadata": {
-        "id": "32c454a8-181b-482b-873a-81d6ffde4674"
-      },
-      "source": [
-        "Smaller models, or more complicated formats, may require more than one shot. Here a sample with two shots."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8ce600f7-f92e-4cf7-be4a-408f12eb39d6",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8ce600f7-f92e-4cf7-be4a-408f12eb39d6",
-        "outputId": "a6f90f5d-6d68-4b3d-ccb5-5848ae4e3e62"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Driver: Fernando Alonso. \n",
-            "Team: Renault.\n"
-          ]
-        }
-      ],
-      "source": [
-        "#Few shots\n",
-        "context_user = [\n",
-        "    {'role':'system', 'content':\n",
-        "     \"\"\"You are an expert in F1.\n",
-        "\n",
-        "     Who won the 2010 f1 championship?\n",
-        "     Driver: Sebastian Bettel.\n",
-        "     Team: Red Bull Renault.\n",
-        "\n",
-        "     Who won the 2009 f1 championship?\n",
-        "     Driver: Jenson Button.\n",
-        "     Team: BrawnGP.\"\"\"}\n",
-        "]\n",
-        "print(return_OAIResponse(\"Who won the F1 2006?\", context_user))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4b29898a-f715-46d4-b74b-9f95d3112d38",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4b29898a-f715-46d4-b74b-9f95d3112d38",
-        "outputId": "75f63fe3-0efc-45ed-dd45-71dbbb08d7a6"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Driver: Lewis Hamilton.\n",
-            "Team: Mercedes.\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(return_OAIResponse(\"Who won the F1 2019?\", context_user))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "5f1b71c4-6583-4dcb-b987-02abf6aa4a86",
-      "metadata": {
-        "id": "5f1b71c4-6583-4dcb-b987-02abf6aa4a86"
-      },
-      "source": [
-        "We've been creating the prompt without using OpenAI's roles, and as we've seen, it worked correctly.\n",
-        "\n",
-        "However, the proper way to do this is by using these roles to construct the prompt, making the model's learning process even more effective.\n",
-        "\n",
-        "By not feeding it the entire prompt as if they were system commands, we enable the model to learn from a conversation, which is more realistic for it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "20fa4a25-01a6-4f22-98db-ab7ccc9ba115",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "20fa4a25-01a6-4f22-98db-ab7ccc9ba115",
-        "outputId": "868d2040-ca3c-4a47-a1e8-1e08d581191d"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Driver: Lewis Hamilton. \n",
-            "Team: Mercedes. \n",
-            "Points: 413.\n"
-          ]
-        }
-      ],
-      "source": [
-        "#Recomended solution\n",
-        "context_user = [\n",
-        "    {'role':'system', 'content':'You are and expert in f1.\\n\\n'},\n",
-        "    {'role':'user', 'content':'Who won the 2010 f1 championship?'},\n",
-        "    {'role':'assistant', 'content':\"\"\"Driver: Sebastian Bettel. \\nTeam: Red Bull. \\nPoints: 256. \"\"\"},\n",
-        "    {'role':'user', 'content':'Who won the 2009 f1 championship?'},\n",
-        "    {'role':'assistant', 'content':\"\"\"Driver: Jenson Button. \\nTeam: BrawnGP. \\nPoints: 95. \"\"\"},\n",
-        "]\n",
-        "\n",
-        "print(return_OAIResponse(\"Who won the F1 2019?\", context_user))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ac6f6b42-f351-496b-a7e8-1286426457eb",
-      "metadata": {
-        "id": "ac6f6b42-f351-496b-a7e8-1286426457eb"
-      },
-      "source": [
-        "We could also address it by using a more conventional prompt, describing what we want and how we want the format.\n",
-        "\n",
-        "However, it's essential to understand that in this case, the model is following instructions, whereas in the case of use shots, it is learning in real-time during inference."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "36c32a32-c348-45b2-85ee-ab4500438c49",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "36c32a32-c348-45b2-85ee-ab4500438c49",
-        "outputId": "4c970dde-37ff-41a9-8d4e-37bb727f47a6"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Driver: Lewis Hamilton\n",
-            "Team: Mercedes\n",
-            "Points: 413\n"
-          ]
-        }
-      ],
-      "source": [
-        "context_user = [\n",
-        "    {'role':'system', 'content':\"\"\"You are and expert in f1.\n",
-        "    You are going to answew the question of the user giving the name of the rider,\n",
-        "    the name of the team and the points of the champion, following the format:\n",
-        "    Drive:\n",
-        "    Team:\n",
-        "    Points: \"\"\"\n",
-        "    }\n",
-        "]\n",
-        "\n",
-        "print(return_OAIResponse(\"Who won the F1 2019?\", context_user))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "context_user = [\n",
-        "    {'role':'system', 'content':\n",
-        "     \"\"\"You are classifying .\n",
-        "\n",
-        "     Who won the 2010 f1 championship?\n",
-        "     Driver: Sebastian Bettel.\n",
-        "     Team: Red Bull Renault.\n",
-        "\n",
-        "     Who won the 2009 f1 championship?\n",
-        "     Driver: Jenson Button.\n",
-        "     Team: BrawnGP.\"\"\"}\n",
-        "]\n",
-        "print(return_OAIResponse(\"Who won the F1 2006?\", context_user))"
-      ],
-      "metadata": {
-        "id": "KNDL1GzVngyL"
-      },
-      "id": "KNDL1GzVngyL",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Few Shots for classification.\n"
-      ],
-      "metadata": {
-        "id": "qZPNTLMPnkQ4"
-      },
-      "id": "qZPNTLMPnkQ4"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "context_user = [\n",
-        "    {'role':'system', 'content':\n",
-        "     \"\"\"You are an expert in reviewing product opinions and classifying them as positive or negative.\n",
-        "\n",
-        "     It fulfilled its function perfectly, I think the price is fair, I would buy it again.\n",
-        "     Setiment: Positive\n",
-        "\n",
-        "     It didn't work bad, but I wouldn't buy it again, maybe it's a bit expensive for what it does.\n",
-        "     Sentiment: Negative.\n",
-        "\n",
-        "     I wouldn't know what to say, my son uses it, but he doesn't love it.\n",
-        "     Sentiment: Neutral\n",
-        "     \"\"\"}\n",
-        "]\n",
-        "print(return_OAIResponse(\"I'm not going to return it, but I don't plan to buy it again.\", context_user))"
-      ],
-      "metadata": {
-        "id": "ejcstgTxnnX5",
-        "outputId": "4b91cc73-18f6-4944-a46b-806b02b7becb",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "id": "ejcstgTxnnX5",
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Sentiment: Negative\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "ZHr_75sDqDJp"
-      },
-      "id": "ZHr_75sDqDJp",
-      "execution_count": null,
-      "outputs": []
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.12"
-    },
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "view-in-github",
+    "colab_type": "text"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/peremartra/Large-Language-Model-Notebooks-Course/blob/main/1-Introduction%20to%20LLMs%20with%20OpenAI/Prompt_Engineering_OpenAI.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ],
+   "id": "42abd0d1768faece"
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "source": [
+    "<div align=\"center\">\n",
+    "<h1><a href=\"https://github.com/peremartra/Large-Language-Model-Notebooks-Course\">Learn by Doing LLM Projects</a></h1>\n",
+    "    <h3>Understand And Apply Large Language Models</h3>\n",
+    "    <h2>Brief Introduction to Prompt Engineering with OpenAI</h2>\n",
+    "    by <b>Pere Martra</b>\n",
+    "</div>\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "<div align=\"center\">\n",
+    "    &nbsp;\n",
+    "    <a target=\"_blank\" href=\"https://www.linkedin.com/in/pere-martra/\"><img src=\"https://img.shields.io/badge/style--5eba00.svg?label=LinkedIn&logo=linkedin&style=social\"></a>\n",
+    "    \n",
+    "</div>\n",
+    "\n",
+    "<br>\n",
+    "<hr>\n"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "9c4700eb-00ef-433f-b574-2fb7f644226d"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34723a72-1601-4685-a0ba-bff544425d48",
+   "metadata": {
+    "id": "34723a72-1601-4685-a0ba-bff544425d48"
+   },
+   "source": [
+    "In this notebook, we'll explore small prompt engineering techniques and recommendations that will help us elicit responses from the models that are better suited to our needs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fe5f658a-708f-406c-a1cb-95e3482ae760",
+   "metadata": {
+    "id": "fe5f658a-708f-406c-a1cb-95e3482ae760",
+    "outputId": "a44c5457-94f4-4357-c66b-8682253aee0a",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\u001B[2K     \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m217.8/217.8 kB\u001B[0m \u001B[31m3.0 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K     \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m75.0/75.0 kB\u001B[0m \u001B[31m5.6 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K     \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m76.9/76.9 kB\u001B[0m \u001B[31m8.3 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[2K     \u001B[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001B[0m \u001B[32m58.3/58.3 kB\u001B[0m \u001B[31m4.8 MB/s\u001B[0m eta \u001B[36m0:00:00\u001B[0m\n",
+      "\u001B[?25h\u001B[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "llmx 0.0.15a0 requires cohere, which is not installed.\n",
+      "llmx 0.0.15a0 requires tiktoken, which is not installed.\u001B[0m\u001B[31m\n",
+      "\u001B[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install -q openai==1.1.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fba193cc-d8a0-4ad2-8177-380204426859",
+   "metadata": {
+    "id": "fba193cc-d8a0-4ad2-8177-380204426859"
+   },
+   "outputs": [],
+   "source": [
+    "# if you need an API Key from OpenAI\n",
+    "#https://platform.openai.com/account/api-keys\n",
+    "\n",
+    "import openai\n",
+    "\n",
+    "openai.api_key=\"your-api-key\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "502cfc93-21e0-498f-9650-37bc6ddd514d",
+   "metadata": {
+    "id": "502cfc93-21e0-498f-9650-37bc6ddd514d"
+   },
+   "source": [
+    "# Formatting the answer with Few Shot Samples.\n",
+    "\n",
+    "To obtain the model's response in a specific format, we have various options, but one of the most convenient is to use Few-Shot Samples. This involves presenting the model with pairs of user queries and example responses.\n",
+    "\n",
+    "Large models like GPT-3.5 respond well to the examples provided, adapting their response to the specified format.\n",
+    "\n",
+    "Depending on the number of examples given, this technique can be referred to as:\n",
+    "* Zero-Shot.\n",
+    "* One-Shot.\n",
+    "* Few-Shots.\n",
+    "\n",
+    "With One Shot should be enough, and it is recommended to use a maximum of six shots. It's important to remember that this information is passed in each query and occupies space in the input prompt.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a8344712-06d7-4c24-83d8-f36d62926e5e",
+   "metadata": {
+    "id": "a8344712-06d7-4c24-83d8-f36d62926e5e"
+   },
+   "outputs": [],
+   "source": [
+    "# Function to call the model.\n",
+    "def return_OAIResponse(user_message, context):\n",
+    "\n",
+    "    newcontext = context.copy()\n",
+    "    newcontext.append({'role':'user', 'content':\"question: \" + user_message})\n",
+    "\n",
+    "    response = openai.chat.completions.create(\n",
+    "            model=\"gpt-3.5-turbo\",\n",
+    "            messages=newcontext,\n",
+    "            temperature=1,\n",
+    "        )\n",
+    "\n",
+    "    return (response.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f611d73d-9330-466d-b705-543667e1b561",
+   "metadata": {
+    "id": "f611d73d-9330-466d-b705-543667e1b561"
+   },
+   "source": [
+    "In this zero-shots prompt we obtain a correct response, but without formatting, as the model incorporates the information he wants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "647790be-fdb8-4692-a82e-7e3a0220f72a",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "647790be-fdb8-4692-a82e-7e3a0220f72a",
+    "outputId": "4c4a9f4f-67c9-4a11-837f-1a1fd6b516ff"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Sebastian Vettel won the Formula 1 World Championship in 2010. He drove for the Red Bull Racing team and became the youngest ever F1 World Champion at the age of 23. Vettel secured a total of five race wins and nine pole positions during the 2010 season.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#zero-shot\n",
+    "context_user = [\n",
+    "    {'role':'system', 'content':'You are an expert in F1.'}\n",
+    "]\n",
+    "print(return_OAIResponse(\"Who won the F1 2010?\", context_user))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e87a9a0a-c1b9-4759-b52f-f6547d29b4c8",
+   "metadata": {
+    "id": "e87a9a0a-c1b9-4759-b52f-f6547d29b4c8"
+   },
+   "source": [
+    "For a model as large and good as GPT 3.5, a single shot is enough to learn the output format we expect.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "33ac7693-6cf3-44f7-b2ff-55d8a36fe775",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "33ac7693-6cf3-44f7-b2ff-55d8a36fe775",
+    "outputId": "5278df23-8797-4dc2-9340-ac29c1318a9c"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Driver: Sebastian Vettel.\n",
+      "Team: Red Bull Racing.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#one-shot\n",
+    "context_user = [\n",
+    "    {'role':'system', 'content':\n",
+    "     \"\"\"You are an expert in F1.\n",
+    "\n",
+    "     Who won the 2000 f1 championship?\n",
+    "     Driver: Michael Schumacher.\n",
+    "     Team: Ferrari.\"\"\"}\n",
+    "]\n",
+    "print(return_OAIResponse(\"Who won the F1 2011?\", context_user))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32c454a8-181b-482b-873a-81d6ffde4674",
+   "metadata": {
+    "id": "32c454a8-181b-482b-873a-81d6ffde4674"
+   },
+   "source": [
+    "Smaller models, or more complicated formats, may require more than one shot. Here a sample with two shots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ce600f7-f92e-4cf7-be4a-408f12eb39d6",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "8ce600f7-f92e-4cf7-be4a-408f12eb39d6",
+    "outputId": "a6f90f5d-6d68-4b3d-ccb5-5848ae4e3e62"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Driver: Fernando Alonso. \n",
+      "Team: Renault.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Few shots\n",
+    "context_user = [\n",
+    "    {'role':'system', 'content':\n",
+    "     \"\"\"You are an expert in F1.\n",
+    "\n",
+    "     Who won the 2010 f1 championship?\n",
+    "     Driver: Sebastian Vettel.\n",
+    "     Team: Red Bull Renault.\n",
+    "\n",
+    "     Who won the 2009 f1 championship?\n",
+    "     Driver: Jenson Button.\n",
+    "     Team: BrawnGP.\"\"\"}\n",
+    "]\n",
+    "print(return_OAIResponse(\"Who won the F1 2006?\", context_user))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b29898a-f715-46d4-b74b-9f95d3112d38",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4b29898a-f715-46d4-b74b-9f95d3112d38",
+    "outputId": "75f63fe3-0efc-45ed-dd45-71dbbb08d7a6"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Driver: Lewis Hamilton.\n",
+      "Team: Mercedes.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(return_OAIResponse(\"Who won the F1 2019?\", context_user))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f1b71c4-6583-4dcb-b987-02abf6aa4a86",
+   "metadata": {
+    "id": "5f1b71c4-6583-4dcb-b987-02abf6aa4a86"
+   },
+   "source": [
+    "We've been creating the prompt without using OpenAI's roles, and as we've seen, it worked correctly.\n",
+    "\n",
+    "However, the proper way to do this is by using these roles to construct the prompt, making the model's learning process even more effective.\n",
+    "\n",
+    "By not feeding it the entire prompt as if they were system commands, we enable the model to learn from a conversation, which is more realistic for it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20fa4a25-01a6-4f22-98db-ab7ccc9ba115",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "20fa4a25-01a6-4f22-98db-ab7ccc9ba115",
+    "outputId": "868d2040-ca3c-4a47-a1e8-1e08d581191d"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Driver: Lewis Hamilton. \n",
+      "Team: Mercedes. \n",
+      "Points: 413.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Recomended solution\n",
+    "context_user = [\n",
+    "    {'role':'system', 'content':'You are and expert in f1.\\n\\n'},\n",
+    "    {'role':'user', 'content':'Who won the 2010 f1 championship?'},\n",
+    "    {'role':'assistant', 'content':\"\"\"Driver: Sebastian Vettel. \\nTeam: Red Bull. \\nPoints: 256. \"\"\"},\n",
+    "    {'role':'user', 'content':'Who won the 2009 f1 championship?'},\n",
+    "    {'role':'assistant', 'content':\"\"\"Driver: Jenson Button. \\nTeam: BrawnGP. \\nPoints: 95. \"\"\"},\n",
+    "]\n",
+    "\n",
+    "print(return_OAIResponse(\"Who won the F1 2019?\", context_user))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac6f6b42-f351-496b-a7e8-1286426457eb",
+   "metadata": {
+    "id": "ac6f6b42-f351-496b-a7e8-1286426457eb"
+   },
+   "source": [
+    "We could also address it by using a more conventional prompt, describing what we want and how we want the format.\n",
+    "\n",
+    "However, it's essential to understand that in this case, the model is following instructions, whereas in the case of use shots, it is learning in real-time during inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36c32a32-c348-45b2-85ee-ab4500438c49",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "36c32a32-c348-45b2-85ee-ab4500438c49",
+    "outputId": "4c970dde-37ff-41a9-8d4e-37bb727f47a6"
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Driver: Lewis Hamilton\n",
+      "Team: Mercedes\n",
+      "Points: 413\n"
+     ]
+    }
+   ],
+   "source": [
+    "context_user = [\n",
+    "    {'role':'system', 'content':\"\"\"You are and expert in f1.\n",
+    "    You are going to answer the question of the user giving the name of the rider,\n",
+    "    the name of the team and the points of the champion, following the format:\n",
+    "    Drive:\n",
+    "    Team:\n",
+    "    Points: \"\"\"\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "print(return_OAIResponse(\"Who won the F1 2019?\", context_user))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "context_user = [\n",
+    "    {'role':'system', 'content':\n",
+    "     \"\"\"You are classifying .\n",
+    "\n",
+    "     Who won the 2010 f1 championship?\n",
+    "     Driver: Sebastian Vettel.\n",
+    "     Team: Red Bull Renault.\n",
+    "\n",
+    "     Who won the 2009 f1 championship?\n",
+    "     Driver: Jenson Button.\n",
+    "     Team: BrawnGP.\"\"\"}\n",
+    "]\n",
+    "print(return_OAIResponse(\"Who won the F1 2006?\", context_user))"
+   ],
+   "metadata": {
+    "id": "KNDL1GzVngyL"
+   },
+   "id": "KNDL1GzVngyL",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Few Shots for classification.\n"
+   ],
+   "metadata": {
+    "id": "qZPNTLMPnkQ4"
+   },
+   "id": "qZPNTLMPnkQ4"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "context_user = [\n",
+    "    {'role':'system', 'content':\n",
+    "     \"\"\"You are an expert in reviewing product opinions and classifying them as positive or negative.\n",
+    "\n",
+    "     It fulfilled its function perfectly, I think the price is fair, I would buy it again.\n",
+    "     Sentiment: Positive\n",
+    "\n",
+    "     It didn't work bad, but I wouldn't buy it again, maybe it's a bit expensive for what it does.\n",
+    "     Sentiment: Negative.\n",
+    "\n",
+    "     I wouldn't know what to say, my son uses it, but he doesn't love it.\n",
+    "     Sentiment: Neutral\n",
+    "     \"\"\"}\n",
+    "]\n",
+    "print(return_OAIResponse(\"I'm not going to return it, but I don't plan to buy it again.\", context_user))"
+   ],
+   "metadata": {
+    "id": "ejcstgTxnnX5",
+    "outputId": "4b91cc73-18f6-4944-a46b-806b02b7becb",
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    }
+   },
+   "id": "ejcstgTxnnX5",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Sentiment: Negative\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [],
+   "metadata": {
+    "id": "ZHr_75sDqDJp"
+   },
+   "id": "ZHr_75sDqDJp",
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "colab": {
+   "provenance": [],
+   "include_colab_link": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Update Prompt Engineering OpenAI notebook

The main change in the update was adjusting and correcting a few typos, fixing some grammar errors, translating to English a text that was in Spanish, and fixing a driver's last name, which had a spelling error.

  - Introducction -> Introducction
  - a API -> an API
  - Formating -> Formatting
  - Functio -> Function
  - "A un modelo tan grande y bueno como GPT 3.5 le basta un solo shot para aprende el formato de salida que esperamos." -> "For a model as large and good as GPT 3.5, a single shot is enough to learn the output format we expect."
  - Bettel -> Vettel
  - answew -> answer
  - Setiment -> Sentiment

This improves the readability and comprehension of the document. 
The update does not alter the main code or results.