### PR TITLE
docs: add CONTRIBUTING.md, CODE_OF_CONDUCT.md, CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+- Community documentation: CONTRIBUTING.md and CODE_OF_CONDUCT.md
+
+---
+
+*For the full list of releases, see the [releases page](../../releases).*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Large-Language-Model-Notebooks-Course
+
+Thank you for your interest in contributing!
+
+## Ways to Contribute
+
+- **Bug reports** – If you find an error in the code, notebooks, or documentation, please [open an issue](../../issues/new)
+- **Fixes** – Submit a pull request with the correction and a brief explanation
+- **Enhancements** – Suggest new content or improvements via [issues](../../issues) or [discussions](../../discussions)
+
+## Pull Request Process
+
+1. Fork this repository
+2. Create a feature branch: `git checkout -b fix/your-change`
+3. Make your changes and test them locally
+4. Commit with a clear message: `git commit -m "fix: describe what changed"`
+5. Push and open a pull request against the default branch
+
+## Style Guidelines
+
+- Keep examples minimal and self-contained
+- Prefer clarity over brevity in explanations
+- Match the existing code style and formatting
+
+## Reporting Issues
+
+When reporting a bug, please include:
+- What you expected to happen
+- What actually happened
+- Steps to reproduce (OS, Python/library versions)
+
+## Code of Conduct
+
+Please see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community guidelines.
+
+---
+
+*Documentation contributed by [Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Summary

This PR adds community health documentation files that are commonly expected in open-source projects:

- **CONTRIBUTING.md**
- **CODE_OF_CONDUCT.md**
- **CHANGELOG.md**

### Details

- **CONTRIBUTING.md** – Explains how to report bugs, suggest improvements, and submit pull requests
- **CODE_OF_CONDUCT.md** – Contributor Covenant 2.1, the widely-adopted community standard
- **CHANGELOG.md** – Starter changelog following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format

These files help new contributors understand how to engage with the project and set clear community expectations.
